### PR TITLE
Cleanup build tools within translation move

### DIFF
--- a/cmake/modules/LXQtTranslateTs.cmake
+++ b/cmake/modules/LXQtTranslateTs.cmake
@@ -66,32 +66,12 @@
 #       COMPONENT Optional install component. Only effective if INSTALL_DIR
 #                   present. Defaults to "Runtime".
 #
-#       PULL_TRANSLATIONS Optional flag. If set, the translations are pulled
-#           from external repository in cmake phase (not in build/make time)
-#           into directory "${TRANSLATION_DIR}/${REPO_SUBDIR}".
-#
-#       CLEAN_TRANSLATIONS Optional flag. If set, the externally pulled
-#                          translations are removed.
-#
-#       REPO_SUBDIR Optional path in the "translations repository" to directory
-#           with translations. Only effective if PULL_TRANSLATIONS enabled.
-#           Defaults to "${TEMPLATE}".
-#
-#       TRANSLATIONS_REPO External git repository with translations - only the ${TEMPLATE} directory
-#           is pulled (using the "sparse checkout").
-#           Optional (defaults to "https://github.com/lxqt/lxqt-l10n.git").
-#
-#       TRANSLATIONS_REFSPEC Optional refspec of external repository. Used in git pull.
-#           Defaults to "master".
 
 # CMake v2.8.3 needed to use the CMakeParseArguments module
 cmake_minimum_required(VERSION 2.8.3 FATAL_ERROR)
 
 # We use our patched version to round a annoying bug.
 include(Qt5PatchedLinguistToolsMacros)
-
-option(PULL_TRANSLATIONS "Pull translations" Yes)
-option(CLEAN_TRANSLATIONS "Clean translations" No)
 
 function(lxqt_translate_ts qmFiles)
     set(oneValueArgs
@@ -131,99 +111,7 @@ function(lxqt_translate_ts qmFiles)
     endif()
     get_filename_component(TR_TRANSLATION_DIR "${TR_TRANSLATION_DIR}" ABSOLUTE)
 
-    if (NOT DEFINED TR_CLEAN_TRANSLATIONS)
-        set(TR_CLEAN_TRANSLATIONS "No")
-    endif()
-    if (NOT DEFINED TR_PULL_TRANSLATIONS)
-        set(TR_PULL_TRANSLATIONS "No")
-    endif()
-    if (NOT DEFINED TR_REPO_SUBDIR)
-        set(TR_REPO_SUBDIR "${TR_TEMPLATE}")
-    endif()
-
-    if (NOT DEFINED TR_TRANSLATIONS_REPO)
-        set(TR_TRANSLATIONS_REPO "https://github.com/lxqt/lxqt-l10n.git")
-    endif()
-
-    if (NOT DEFINED TR_TRANSLATIONS_REFSPEC)
-        set(TR_TRANSLATIONS_REFSPEC "master")
-    endif()
-
-    if (TR_CLEAN_TRANSLATIONS)
-        message(STATUS "Cleaning translations dir '${TR_TRANSLATION_DIR}' ...")
-        set(DIR_TO_REMOVE "${TR_TRANSLATION_DIR}/${TR_REPO_SUBDIR}")
-        get_filename_component(PARENT_DIR "${DIR_TO_REMOVE}" DIRECTORY)
-        while (NOT "${PARENT_DIR}" STREQAL "${TR_TRANSLATION_DIR}")
-            set(DIR_TO_REMOVE "${PARENT_DIR}")
-            get_filename_component(PARENT_DIR "${DIR_TO_REMOVE}" DIRECTORY)
-        endwhile ()
-        #TODO: is there a way to check successfulness of file command !?!
-        file(REMOVE_RECURSE "${TR_TRANSLATION_DIR}/.git" "${DIR_TO_REMOVE}")
-    endif ()
-
-    if (TR_PULL_TRANSLATIONS)
-        find_package(Git REQUIRED)
-        if (NOT (GIT_FOUND AND GIT_VERSION_STRING VERSION_GREATER "1.7.0"))
-            message(FATAL_ERROR "Git > 1.7.0 is needed For pulling translations!")
-        endif ()
-        if (NOT EXISTS "${TR_TRANSLATION_DIR}/${TR_REPO_SUBDIR}")
-            message(STATUS "Setting git repository in the translations dir '${TR_TRANSLATION_DIR}' ...")
-            if (EXISTS "${TR_TRANSLATION_DIR}/.git")
-                execute_process(COMMAND rm -Rf .git
-                    WORKING_DIRECTORY  "${TR_TRANSLATION_DIR}"
-                    RESULT_VARIABLE ex_result
-                    )
-
-                if (NOT "${ex_result}" EQUAL 0)
-                    message(FATAL_ERROR "Initialization(cleanup) of translations dir failed!")
-                endif ()
-            endif()
-
-            # make sure the dir exist, otherwise git init will fail
-            file(MAKE_DIRECTORY "${TR_TRANSLATION_DIR}")
-
-            execute_process(COMMAND "${GIT_EXECUTABLE}" init
-                WORKING_DIRECTORY  "${TR_TRANSLATION_DIR}"
-                RESULT_VARIABLE ex_result
-                )
-            if (NOT "${ex_result}" EQUAL 0)
-                message(FATAL_ERROR "Initialization(init) of translations dir failed!")
-            endif ()
-
-            execute_process(COMMAND "${GIT_EXECUTABLE}" remote add  origin "${TR_TRANSLATIONS_REPO}"
-                WORKING_DIRECTORY  "${TR_TRANSLATION_DIR}"
-                RESULT_VARIABLE ex_result
-                )
-            if (NOT "${ex_result}" EQUAL 0)
-                message(FATAL_ERROR "Initialization(remote) of translations dir failed!")
-            endif ()
-
-            execute_process(COMMAND "${GIT_EXECUTABLE}" config core.sparseCheckout true
-                WORKING_DIRECTORY  "${TR_TRANSLATION_DIR}"
-                RESULT_VARIABLE ex_result
-                )
-            if (NOT "${ex_result}" EQUAL 0)
-                message(FATAL_ERROR "Initialization(config) of translations dir failed!")
-            endif ()
-
-            file(WRITE "${TR_TRANSLATION_DIR}/.git/info/sparse-checkout" "${TR_REPO_SUBDIR}")
-        endif ()
-
-        message(STATUS "Pulling the translations...")
-        execute_process(COMMAND "${GIT_EXECUTABLE}" pull origin "${TR_TRANSLATIONS_REFSPEC}"
-            WORKING_DIRECTORY  "${TR_TRANSLATION_DIR}"
-            RESULT_VARIABLE ex_result
-            )
-        if (NOT "${ex_result}" EQUAL 0)
-            message(FATAL_ERROR "Pulling translations failed!")
-        endif ()
-    endif ()
-
-    #project/module can use it's own translations (not from external)
-    if (EXISTS "${TR_TRANSLATION_DIR}/${TR_REPO_SUBDIR}/")
-        file(GLOB tsFiles "${TR_TRANSLATION_DIR}/${TR_REPO_SUBDIR}/*_*.ts")
-        set(templateFile "${TR_TRANSLATION_DIR}/${TR_REPO_SUBDIR}/${TR_TEMPLATE}.ts")
-    else ()
+    if (EXISTS "${TR_TRANSLATION_DIR}")
         file(GLOB tsFiles "${TR_TRANSLATION_DIR}/${TR_TEMPLATE}_*.ts")
         set(templateFile "${TR_TRANSLATION_DIR}/${TR_TEMPLATE}.ts")
     endif ()


### PR DESCRIPTION
We don't pull anything from external repositories anymore - thus the fuctionality
for pulling and cleaning up can be removed. Also handled the standard translations/l10n
path for *.ts files with fallback to translations/.