### PR TITLE
Drop 0X and 11 support, require c++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 project(lxqt-build-tools)
-
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+# CMP0000 - A minimum required CMake version must be specified.
+# Note that the command invocation must appear in the CMakeLists.txt
+# file itself; a call in an included file is not sufficient.
+cmake_minimum_required(VERSION 3.6.2 FATAL_ERROR)
 
 option(WITH_XDG_DIRS_FALLBACK "Use our XDG_CONFIG_DIRS fallback" ON)
 
 set(LXQT_BUILD_TOOLS_MAJOR_VERSION 0)
-set(LXQT_BUILD_TOOLS_MINOR_VERSION 5)
+set(LXQT_BUILD_TOOLS_MINOR_VERSION 6)
 set(LXQT_BUILD_TOOLS_PATCH_VERSION 0)
 set(LXQT_BUILD_TOOLS_VERSION ${LXQT_BUILD_TOOLS_MAJOR_VERSION}.${LXQT_BUILD_TOOLS_MINOR_VERSION}.${LXQT_BUILD_TOOLS_PATCH_VERSION})
 

--- a/cmake/modules/ECMFindModuleHelpers.cmake
+++ b/cmake/modules/ECMFindModuleHelpers.cmake
@@ -126,11 +126,11 @@
 include(CMakeParseArguments)
 
 macro(ecm_find_package_version_check module_name)
-    if(CMAKE_VERSION VERSION_LESS 2.8.12)
-        message(FATAL_ERROR "CMake 2.8.12 is required by Find${module_name}.cmake")
+    if(CMAKE_VERSION VERSION_LESS 3.6.2)
+        message(FATAL_ERROR "CMake 3.6.2 is required by Find${module_name}.cmake")
     endif()
-    if(CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS 2.8.12)
-        message(AUTHOR_WARNING "Your project should require at least CMake 2.8.12 to use Find${module_name}.cmake")
+    if(CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS 3.6.2)
+        message(AUTHOR_WARNING "Your project should require at least CMake 3.6.2 to use Find${module_name}.cmake")
     endif()
 endmacro()
 

--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -179,17 +179,10 @@ endif()
 
 
 #-----------------------------------------------------------------------------
-# CXX11 and CXX0X requirements
+# CXX14 requirements - no checks, we just set it
 #-----------------------------------------------------------------------------
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
-    message(FATAL "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. C++11 support is required")
-endif()
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ ISO Standard")
 
 
 #-----------------------------------------------------------------------------

--- a/cmake/modules/LXQtTranslateTs.cmake
+++ b/cmake/modules/LXQtTranslateTs.cmake
@@ -62,9 +62,6 @@
 #                   present. Defaults to "Runtime".
 #
 
-# CMake v2.8.3 needed to use the CMakeParseArguments module
-cmake_minimum_required(VERSION 2.8.3 FATAL_ERROR)
-
 # We use our patched version to round a annoying bug.
 include(Qt5PatchedLinguistToolsMacros)
 


### PR DESCRIPTION
While we are on it - just bump the requirement for cmake to 3.6.2
Bumped minor version to 6
fixes lxqt/lxqt/issues/1568