### PR TITLE
Remove link-time optimization for gcc since it breaks qobject_cast() in some cases.

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -150,35 +150,6 @@ endif()
 
 
 #-----------------------------------------------------------------------------
-# Turn on more aggrassive optimizations not supported by CMake
-# References: https://wiki.qt.io/Performance_Tip_Startup_Time
-#-----------------------------------------------------------------------------
-if (CMAKE_COMPILER_IS_GNUCXX OR LXQT_COMPILER_IS_CLANGCXX)
-    # -flto: use link-time optimizations to generate more efficient code
-    if (CMAKE_COMPILER_IS_GNUCXX)
-        set(LTO_FLAGS "-flto -fuse-linker-plugin")
-        # When building static libraries with LTO in gcc >= 4.9,
-        # "gcc-ar" and "gcc-ranlib" should be used instead of "ar" and "ranlib".
-        # references:
-        #   https://gcc.gnu.org/gcc-4.9/changes.html
-        #   https://hubicka.blogspot.tw/2014/04/linktime-optimization-in-gcc-2-firefox.html
-        #   https://github.com/monero-project/monero/pull/1065/commits/1855213c8fb8f8727f4107716aab8e7ba826462b
-        if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9.0")  # gcc >= 4.9
-            set(CMAKE_AR "gcc-ar")
-            set(CMAKE_RANLIB "gcc-ranlib")
-        endif()
-    elseif (LXQT_COMPILER_IS_CLANGCXX)
-        # The link-time optimization of clang++/llvm seems to be too aggrassive.
-        # After testing, it breaks the signal/slots of QObject sometimes.
-        # So disable it for now until there is a solution.
-        # set(LTO_FLAGS "-flto")
-    endif()
-    # apply these options to "Release" build type only
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${LTO_FLAGS}")
-endif()
-
-
-#-----------------------------------------------------------------------------
 # CXX14 requirements - no checks, we just set it
 #-----------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD_REQUIRED True)


### PR DESCRIPTION
I encountered crashes caused by Qt + gcc LTO in the latest ArchLinux.

- Kernel: Linux arch-pc 4.19.9-arch1-1-ARCH #1 SMP PREEMPT Fri Dec 14 00:58:26 UTC 2018 x86_64 GNU/Linux
- g++ (GCC) 8.2.1 20181127
- qt5-base 5.12.0-1

When turning on link-time optimization in g++, qobject_cast() will crash in some cases (in lxqt-panel for example).
The root cause is it generated wrong machine code, so the qobject_cast() referenced the wrong MetaObject. QObject::metaObject() should equal to &QObject::staticMetaObject, but it's not.

Turning off LTO solved the problem.