### PR TITLE
LXQtCompilerSettings: Set C++ extensions to be disabled

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -160,6 +160,7 @@ endif()
 # CXX14 requirements - no checks, we just set it
 #-----------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ ISO Standard")
 
 


### PR DESCRIPTION
Avoid things like: -std=g++11 replacing -std=c++11.
At linking time it can result in can result in a mix of standard library
implementations.

If one needs extensions, they can be enabled at a target level:
set_target_properties(myTarget PROPERTIES
    CXX_STANDARD 11
    CXX_STANDARD_REQUIRED YES
    CXX_EXTENSIONS ON
)