### PR TITLE
LXQtCompilerSettings: Enforce no strings casts

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -73,6 +73,10 @@ include(CheckCXXCompilerFlag)
 #-----------------------------------------------------------------------------
 add_definitions(
     -DQT_USE_QSTRINGBUILDER
+    -DQT_NO_CAST_FROM_ASCII
+    -DQT_NO_CAST_TO_ASCII
+    -DQT_NO_URL_CAST_FROM_STRING
+    -DQT_NO_CAST_FROM_BYTEARRAY
     -DQT_NO_FOREACH
 )
 


### PR DESCRIPTION
Enforcing it at a global level.