### PR TITLE
Bump version and min. Qt version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ lxqt-build-tools-0.7.0 / 2020-04-21
   * Added a FindClazy CMake module.
   * Enabled Clazy option when building with clang.
   * Adds CMake find modules for some xdg-utils tools.
+  * The minimum Qt version is bumped to 5.10.0.
 
 lxqt-build-tools-0.6.0 / 2018-01-25
 ===================================

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+lxqt-build-tools-0.7.0 / 2020-04-21
+===================================
+  * Bump version to 0.7.0.
+  * Initial support for Xcode (AppleClang and ld64).
+  * Added a section for settings related to CMake build.
+  * Set C++ extensions to be disabled.
+  * Forbid string casts in LXQtCompilerSettings.
+  * Added a FindClazy CMake module.
+  * Enabled Clazy option when building with clang.
+  * Adds CMake find modules for some xdg-utils tools.
 
 lxqt-build-tools-0.6.0 / 2018-01-25
 ===================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(LXQT_BUILD_TOOLS_VERSION ${LXQT_BUILD_TOOLS_MAJOR_VERSION}.${LXQT_BUILD_TOOL
 
 
 # Check for needed versions
-# We need at least Qt 5.7.1 and glib-2.0 >= 2.50 to build all LXQt parts
+# We need at least Qt 5.10.0 and glib-2.0 >= 2.50 to build all LXQt parts
 find_package(PkgConfig REQUIRED)
 find_package(Qt5Core "5.10.0"  REQUIRED)
 pkg_check_modules(GLIB2 glib-2.0>=2.50 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(lxqt-build-tools)
 option(WITH_XDG_DIRS_FALLBACK "Use our XDG_CONFIG_DIRS fallback" ON)
 
 set(LXQT_BUILD_TOOLS_MAJOR_VERSION 0)
-set(LXQT_BUILD_TOOLS_MINOR_VERSION 6)
+set(LXQT_BUILD_TOOLS_MINOR_VERSION 7)
 set(LXQT_BUILD_TOOLS_PATCH_VERSION 0)
 set(LXQT_BUILD_TOOLS_VERSION ${LXQT_BUILD_TOOLS_MAJOR_VERSION}.${LXQT_BUILD_TOOLS_MINOR_VERSION}.${LXQT_BUILD_TOOLS_PATCH_VERSION})
 
@@ -17,7 +17,7 @@ set(LXQT_BUILD_TOOLS_VERSION ${LXQT_BUILD_TOOLS_MAJOR_VERSION}.${LXQT_BUILD_TOOL
 # Check for needed versions
 # We need at least Qt 5.7.1 and glib-2.0 >= 2.50 to build all LXQt parts
 find_package(PkgConfig REQUIRED)
-find_package(Qt5Core "5.7.1"  REQUIRED)
+find_package(Qt5Core "5.10.0"  REQUIRED)
 pkg_check_modules(GLIB2 glib-2.0>=2.50 REQUIRED)
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
We can't use Qt < 5.10 in some projects. It's better to change 5.7.1 here.