### PR TITLE
Removes some LXQt dependencies version checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,6 @@ set(LXQT_BUILD_TOOLS_MINOR_VERSION 7)
 set(LXQT_BUILD_TOOLS_PATCH_VERSION 0)
 set(LXQT_BUILD_TOOLS_VERSION ${LXQT_BUILD_TOOLS_MAJOR_VERSION}.${LXQT_BUILD_TOOLS_MINOR_VERSION}.${LXQT_BUILD_TOOLS_PATCH_VERSION})
 
-
-# Check for needed versions
-# We need at least Qt 5.10.0 and glib-2.0 >= 2.50 to build all LXQt parts
-find_package(PkgConfig REQUIRED)
-find_package(Qt5Core "5.10.0"  REQUIRED)
-pkg_check_modules(GLIB2 glib-2.0>=2.50 REQUIRED)
-
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs) # Standard directories for installation
 include(cmake/FindInstallConfigPath.cmake) # sets LXQT_ETC_XDG_DIR, if unset


### PR DESCRIPTION
lxqt-build-tools is not the place to handle package version check.
Why only these two ? We check them all or none. None is the best,
each package already handles it's dependencies.