### PR TITLE
Suppress find_package_handle_standard_args package name mismatch warn…

### DIFF
--- a/cmake/modules/ECMFindModuleHelpers.cmake
+++ b/cmake/modules/ECMFindModuleHelpers.cmake
@@ -245,6 +245,7 @@ macro(ecm_find_package_handle_library_components module_name)
             set(${module_name}_VERSION ${${module_name}_${ecm_fpwc_comp}_VERSION})
         endif()
 
+        set(FPHSA_NAME_MISMATCHED 1)
         find_package_handle_standard_args(${module_name}_${ecm_fpwc_comp}
             FOUND_VAR
                 ${module_name}_${ecm_fpwc_comp}_FOUND
@@ -255,6 +256,7 @@ macro(ecm_find_package_handle_library_components module_name)
             VERSION_VAR
                 ${module_name}_${ecm_fpwc_comp}_VERSION
             )
+        unset(FPHSA_NAME_MISMATCHED)
 
         mark_as_advanced(
             ${module_name}_${ecm_fpwc_comp}_LIBRARY


### PR DESCRIPTION
…ing.

Backport of commit:
https://invent.kde.org/frameworks/extra-cmake-modules/-/commit/8d181637a0334eff48bebd8b6e21db3884f3c180

Summary:
cmake introduced a new find_package mismatch check in 3.17, but also allows
user to suppress the warning by setting a variable (Or parameter, but
require new cmake 3.17). Same technique is also used with in cmake,
e.g. FindGTK2.cmake.