### PR TITLE
LXQtCompilerSettings: Drop use of -Bsymbolic

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -164,7 +164,7 @@ if (CMAKE_COMPILER_IS_GNUCXX OR LXQT_COMPILER_IS_CLANGCXX)
         set(NO_UNDEFINED_FLAGS "-Wl,--no-undefined")
         # -Bsymbolic-functions: replace dynamic symbols used internally in
         #                       shared libs with direct addresses.
-        set(SYMBOLIC_FLAGS "-Wl,-Bsymbolic-functions -Wl,-Bsymbolic")
+        set(SYMBOLIC_FLAGS "-Wl,-Bsymbolic-functions")
     endif()
 
     set(CMAKE_SHARED_LINKER_FLAGS


### PR DESCRIPTION
The use of "copy relocations" in ELF executables makes this rather dangerous,
as that moves the definition of the symbol from the library to the executable,
but the library still uses its own definition with -Bsymbolic.

In particular, this led to pcmanfm-qt not saving settings properly
(https://bugzilla.opensuse.org/show_bug.cgi?id=1195421), but can also cause
worse issues like just crashing on startup.

See https://bugreports.qt.io/browse/QTBUG-86173 and
https://bugzilla.opensuse.org/show_bug.cgi?id=1175278 for some details and
discussion about issues with -Bsymbolic.