### PR TITLE
Bump the minimum compatibility level to C++17

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -181,11 +181,11 @@ endif()
 
 
 #-----------------------------------------------------------------------------
-# CXX14 requirements - no checks, we just set it
+# CXX17 requirements - no checks, we just set it
 #-----------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ ISO Standard")
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ ISO Standard")
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Debian [accidentally started](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1029611) a kscreen transition. This would not be an issue, except lxqt-config fails to build from source, as seen in [its respective bug report](https://github.com/lxqt/lxqt-config/issues/903). This is indicative of a wider issue.

We could just add a bunch of `std::experimental::optional` headers, except [kscreen](https://github.com/KDE/kscreen/blob/master/CMakeLists.txt#L13) explicitly sets C++17 as the minimum version (they did this two years ago...). Additionally, the [minimum required GCC version](https://community.kde.org/Frameworks/Policies) for KDE Frameworks is GCC 8, the [second release](https://gcc.gnu.org/projects/cxx-status.html#cxx17) with C++17 support. I think it's reasonable to expect users to be on a version of GCC at least from 2018 or newer.

I'm testing rebuilds of the entire LXQt stack with this change right now. If I come across anything, I will submit pull requests. Once everything is successful, I will merge this PR (assuming there are no objections).