### PR TITLE
fix bashisms in lxqt-transupdate for better portability with non-bash

### DIFF
--- a/lxqt-transupdate
+++ b/lxqt-transupdate
@@ -36,15 +36,15 @@ export QT_SELECT=5
 
 TEMPLATES=$(find . -name \*.ts | grep -v '_')
 for i in $TEMPLATES; do
-  echo "\n\n==== $i ====\n"
-  TRANSDIR=$(dirname $i)
-  SOURCEDIR=$(dirname $TRANSDIR)
+  print "\n\n==== %s ====\n" "$i"
+  TRANSDIR=$(dirname "$i")
+  SOURCEDIR=$(dirname "$TRANSDIR")
   # template-update
-  echo "== Template Update =="
-  echo "lupdate $SOURCEDIR -ts $i -locations absolute -no-obsolete\n"
+  printf "== Template Update =="
+  printf "lupdate %s -ts %s -locations absolute -no-obsolete\n" "$SOURCEDIR" "$i"
   lupdate  $SOURCEDIR -ts $i -locations absolute -no-obsolete
   echo
-  echo "== Language updates =="
-  echo "lupdate $SOURCEDIR -ts $TRANSDIR/*_*.ts -locations absolute -no-obsolete\n"
+  printf "== Language updates =="
+  printf "lupdate %s -ts %s/*_*.ts -locations absolute -no-obsolete\n" "$SOURCEDIR" "$i"
   lupdate  $SOURCEDIR -ts $TRANSDIR/*_*.ts -locations absolute -no-obsolete
 done

--- a/lxqt-transupdate
+++ b/lxqt-transupdate
@@ -36,7 +36,7 @@ export QT_SELECT=5
 
 TEMPLATES=$(find . -name \*.ts | grep -v '_')
 for i in $TEMPLATES; do
-  print "\n\n==== %s ====\n" "$i"
+  printf "\n\n==== %s ====\n" "$i"
   TRANSDIR=$(dirname "$i")
   SOURCEDIR=$(dirname "$TRANSDIR")
   # template-update


### PR DESCRIPTION
Changes to fix "bashims" in lxqt-transupdate, for better portability with non-bash compliant shells.