### PR TITLE
Qt6TranslationLoader.cpp.in: use QLibraryInfo::path()

### DIFF
--- a/cmake/modules/Qt6TranslationLoader.cpp.in
+++ b/cmake/modules/Qt6TranslationLoader.cpp.in
@@ -15,7 +15,7 @@ static void loadQtTranslation()
     QString locale = QLocale::system().name();
     QTranslator *qtTranslator = new QTranslator(qApp);
 
-    if (qtTranslator->load(QLatin1String("qt_") + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
+    if (qtTranslator->load(QLatin1String("qt_") + locale, QLibraryInfo::path(QLibraryInfo::TranslationsPath))) {
         qApp->installTranslator(qtTranslator);
     } else {
         delete qtTranslator;


### PR DESCRIPTION
QLibraryInfo::location() is deprecated in Qt6