### PR TITLE
Bump the minimum compatibility level to C++20

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -181,11 +181,11 @@ endif()
 
 
 #-----------------------------------------------------------------------------
-# CXX17 requirements - no checks, we just set it
+# CXX20 requirements - no checks, we just set it
 #-----------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ ISO Standard")
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ ISO Standard")
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This pull request is very similar to #83, except this is proactive rather than reactive.

kscreen [has bumped its minimum compatibility level to C++20](https://invent.kde.org/plasma/kscreen/-/blob/master/CMakeLists.txt?ref_type=heads#L14). I am seeing a similar trend across other KDE repositories. You can find the C++20 GCC compatibility table [here](https://gcc.gnu.org/projects/cxx-status.html#cxx20).

As this is not currently blocking anything, I will start testing rebuilds with this change and wait for a proper +2.