### PR TITLE
Use PROJECT_NAME instead of CMAKE_PROJECT_NAME for generated config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ file(GLOB toInstallModulesHelpers
 #-----------------------------------------------------------------------------
 # Superbuild mode
 #-----------------------------------------------------------------------------
-set(FIND_MODULES_INSTALL_DIR "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${CMAKE_PROJECT_NAME}/cmake/find-modules/")
-set(MODULES_INSTALL_DIR "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${CMAKE_PROJECT_NAME}/cmake/modules/")
+set(FIND_MODULES_INSTALL_DIR "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}/cmake/find-modules/")
+set(MODULES_INSTALL_DIR "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}/cmake/modules/")
 
 file(COPY
     ${toInstallFindModules}
@@ -71,7 +71,7 @@ file(COPY
 
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/lxqt-build-tools-config.cmake.in"
-    "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
+    "${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
     INSTALL_DESTINATION "neverland"     # required, altough we don't install it
     PATH_VARS
         MODULES_INSTALL_DIR
@@ -94,13 +94,13 @@ configure_file(
 #-----------------------------------------------------------------------------
 # Installable mode
 #-----------------------------------------------------------------------------
-set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${CMAKE_PROJECT_NAME}/")
-set(FIND_MODULES_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${CMAKE_PROJECT_NAME}/find-modules/")
-set(MODULES_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${CMAKE_PROJECT_NAME}/modules/")
+set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME}/")
+set(FIND_MODULES_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME}/find-modules/")
+set(MODULES_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME}/modules/")
 
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/lxqt-build-tools-config.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/install/${CMAKE_PROJECT_NAME}-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/install/${PROJECT_NAME}-config.cmake"
     INSTALL_DESTINATION "${CMAKECONFIG_INSTALL_DIR}"
     PATH_VARS
         MODULES_INSTALL_DIR
@@ -122,13 +122,13 @@ configure_file(
 # The package version file is common to superbuild and installable mode
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/lxqt-build-tools-config-version.cmake.in"
-    "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config-version.cmake"
+    "${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
     @ONLY
 )
 
 install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/install/${CMAKE_PROJECT_NAME}-config.cmake"
-    "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config-version.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/install/${PROJECT_NAME}-config.cmake"
+    "${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
     DESTINATION "${CMAKECONFIG_INSTALL_DIR}"
 )
 


### PR DESCRIPTION
CMAKE_PROJECT_NAME refers to the top-level project, so when lxqt-build-tools is consumed via add_subdirectory() or FetchContent, the generated package config files, version file and module directories were named after the parent project instead of lxqt2-build-tools. This broke find_package(lxqt2-build-tools) for any super-build that includes this project.

Use PROJECT_NAME so the generated files are always named consistently with the subproject, regardless of how it is included.